### PR TITLE
Support Semantic Versioning

### DIFF
--- a/assets/ftp.py
+++ b/assets/ftp.py
@@ -223,4 +223,5 @@ class FTPResource:
 
         return output
 
+
 print(FTPResource().run(os.path.basename(__file__), sys.stdin.read(), sys.argv[1:]))

--- a/assets/ftp.py
+++ b/assets/ftp.py
@@ -9,9 +9,9 @@ import re
 import ssl
 import sys
 import tempfile
-from distutils.version import StrictVersion
 from urllib.parse import urlparse
 
+import semver
 from ftputil.stat import UnixParser
 
 
@@ -188,7 +188,7 @@ class FTPResource:
     def _delete_old_versions(self, keep_versions: int):
         """Delete old versions of file keeping up to specified amont."""
         versions = [m.groupdict() for m in self._regex_matches(self.listdir())]
-        versions.sort(key=lambda x: StrictVersion(x[self.version_key]))
+        versions.sort(key=lambda x: semver.parse_version_info(x[self.version_key]))
 
         old_versions = versions[:-keep_versions]
 
@@ -199,7 +199,7 @@ class FTPResource:
 
     def _versions_to_output(self, versions: [str]):
         """Convert list of k/v dicts into list of `version` output."""
-        versions.sort(key=lambda x: StrictVersion(x[self.version_key]))
+        versions.sort(key=lambda x: semver.parse_version_info(x[self.version_key]))
         output = [{self.version_key: version[self.version_key]} for version in versions]
 
         return output

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 ftputil
+semver

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -14,7 +14,7 @@ CONTENT = '123'
 
 @pytest.fixture
 def free_port():
-    """temporary bind to socket 0 to get a free port assigned by the OS."""
+    """Temporary bind to socket 0 to get a free port assigned by the OS."""
     sock = socket.socket()
     sock.bind(('', 0))
     port = sock.getsockname()[1]
@@ -33,10 +33,7 @@ def work_dir(tmpdir):
 
 @pytest.yield_fixture
 def ftp_server(ftp_root, free_port):
-    """Run FTP server on ftp_root.
-
-    Returns uri to the ftp.
-    """
+    """Run FTP server on ftp_root. Returns uri to the ftp."""
 
     ftp_root.mkdir(DIRECTORY).chmod(stat.S_IWOTH | stat.S_IXOTH | stat.S_IROTH)
 


### PR DESCRIPTION
Version parsing does not follow semantic versioning rules. This pull request updated the resource to follow those rules when parsing and sorting.